### PR TITLE
Fixed broken item images

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -51,10 +51,7 @@ class Item extends React.Component {
             <div className="col-6">
               <img
                 src={this.props.item.image}
-								onError={({ currentTarget }) => {
-									currentTarget.onerror = null;
-									currentTarget.src="../placeholder.png"
-								}}
+								onError={(e)=>{e.target.onerror = null; e.target.src="../placeholder.png"}}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -51,6 +51,10 @@ class Item extends React.Component {
             <div className="col-6">
               <img
                 src={this.props.item.image}
+								onError={({ currentTarget }) => {
+									currentTarget.onerror = null;
+									currentTarget.src="../placeholder.png"
+								}}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,6 +37,10 @@ const ItemPreview = (props) => {
       <img
         alt="item"
         src={item.image}
+				onError={({ currentTarget }) => {
+					currentTarget.onerror = null;
+					currentTarget.src="placeholder.png"
+				}}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,10 +37,7 @@ const ItemPreview = (props) => {
       <img
         alt="item"
         src={item.image}
-				onError={({ currentTarget }) => {
-					currentTarget.onerror = null;
-					currentTarget.src="placeholder.png"
-				}}
+				onError={(e)=>{e.target.onerror = null; e.target.src="placeholder.png"}}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
An onError event was added that changes the src address of the item image to a prepared default image when none is defined.
The instances where the alteration was added are:

frontend/src/components/ItemPreview.js
frontend/src/components/Item/index.js